### PR TITLE
Base implementation 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.freefair.gradle.plugins.lombok.LombokPlugin
-
 plugins {
     java
     `java-library`
@@ -12,9 +10,12 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     mavenLocal()
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.20.2-R0.1-SNAPSHOT")
+
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
@@ -1,7 +1,4 @@
 package net.quantrax.messagebuilder;
 
 public interface MessageBuilder {
-
-
-
 }


### PR DESCRIPTION
Unnecessary line breaks were removed from the MessageBuilder interface. In addition, the build file was updated to remove the LombokPlugin import, add PaperMC's maven repository, and include a new compile-time only dependency on Paper's API.