### PR TITLE
Add message builder service and related utilities

### DIFF
--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
@@ -1,4 +1,21 @@
 package net.quantrax.messagebuilder;
 
+import net.quantrax.messagebuilder.util.PlatformAPI;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
 public interface MessageBuilder {
+
+	static @NotNull MessageBuilder messageBuilder() {
+		return MessageBuilderImpl.Instances.INSTANCE;
+	}
+
+}
+
+interface Provider {
+
+	@ApiStatus.Internal
+	@PlatformAPI
+	@NotNull MessageBuilder messageBuilder();
+
 }

--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilderImpl.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilderImpl.java
@@ -1,0 +1,15 @@
+package net.quantrax.messagebuilder;
+
+import net.quantrax.messagebuilder.util.Services;
+
+import java.util.Optional;
+
+public class MessageBuilderImpl implements MessageBuilder {
+	private static final Optional<Provider> SERVICE = Services.service(Provider.class);
+
+	static final class Instances {
+		static final MessageBuilder INSTANCE = SERVICE
+				.map(Provider::messageBuilder)
+				.orElseGet(MessageBuilderImpl::new);
+	}
+}

--- a/src/main/java/net/quantrax/messagebuilder/util/PlatformAPI.java
+++ b/src/main/java/net/quantrax/messagebuilder/util/PlatformAPI.java
@@ -1,0 +1,12 @@
+package net.quantrax.messagebuilder.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.lang.annotation.*;
+
+@ApiStatus.Internal
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE, ElementType.ANNOTATION_TYPE})
+public @interface PlatformAPI {
+}

--- a/src/main/java/net/quantrax/messagebuilder/util/Services.java
+++ b/src/main/java/net/quantrax/messagebuilder/util/Services.java
@@ -1,0 +1,44 @@
+package net.quantrax.messagebuilder.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Services {
+
+	/**
+	 * Retrieves a service implementation of the specified type.
+	 *
+	 * @param <P>  the type of the service
+	 * @param type the class object representing the type of the service
+	 * @return an {@link Optional} containing the service implementation, or an empty {@link Optional} if no implementation is found
+	 * @throws IllegalStateException if multiple implementations of the service are found
+	 */
+	public static <P> @NotNull Optional<P> service(final @NotNull Class<P> type) {
+		final ServiceLoader<P> loader = Services0.loader(type);
+		final Iterator<P> it = loader.iterator();
+
+		while (it.hasNext()) {
+			final P instance;
+
+			try {
+				instance = it.next();
+			} catch (final Throwable throwable) {
+				continue;
+			}
+
+			if (it.hasNext()) {
+				throw new IllegalStateException("Expected to find one service %s, found multiple".formatted(type));
+			}
+			return Optional.of(instance);
+		}
+
+		return Optional.empty();
+	}
+
+}

--- a/src/main/java/net/quantrax/messagebuilder/util/Services0.java
+++ b/src/main/java/net/quantrax/messagebuilder/util/Services0.java
@@ -1,0 +1,15 @@
+package net.quantrax.messagebuilder.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.ServiceLoader;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class Services0 {
+
+	static <S> ServiceLoader<S> loader(final Class<S> type) {
+		return ServiceLoader.load(type, type.getClassLoader());
+	}
+
+}


### PR DESCRIPTION
This commit introduces a new MessageBuilder service using Java's ServiceLoader mechanism. A util class, Services, has been added to simplify service loading. Also, a new annotation PlatformAPI is introduced for marking API status.