### PR TITLE
Add MessageBuilderTest class

### DIFF
--- a/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
+++ b/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
@@ -1,0 +1,22 @@
+package net.quantrax.messagebuilder;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MessageBuilderTest {
+
+	private static MessageBuilder messageBuilder;
+
+	@BeforeAll
+	static void init() {
+		messageBuilder = MessageBuilder.messageBuilder();
+	}
+
+	@Test
+	void initDoesNotFail() {
+		assertNotNull(messageBuilder, "The MessageBuilder instance is null");
+	}
+
+}


### PR DESCRIPTION
This commit introduces a new test class, MessageBuilderTest, into the project. Inside, a basic test is implemented to ensure that the initialization of the MessageBuilder instance does not fail. The addition of this test class aims to improve code reliability by checking the correct instantiation of the MessageBuilder.