### PR TITLE
Add 'build' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ### Directories
 .gradle
 .idea
+build


### PR DESCRIPTION
The 'build' directory is often changed with every local build and these changes are typically not needed to be tracked by Git. In order to keep the Git history cleaner and reduce unnecessary noise, 'build' directory is added to .gitignore.