### PR TITLE
Refactor Provider class to a new package

### DIFF
--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
@@ -1,7 +1,5 @@
 package net.quantrax.messagebuilder;
 
-import net.quantrax.messagebuilder.util.PlatformAPI;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public interface MessageBuilder {
@@ -9,13 +7,5 @@ public interface MessageBuilder {
 	static @NotNull MessageBuilder messageBuilder() {
 		return MessageBuilderImpl.Instances.INSTANCE;
 	}
-
-}
-
-interface Provider {
-
-	@ApiStatus.Internal
-	@PlatformAPI
-	@NotNull MessageBuilder messageBuilder();
 
 }

--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilderImpl.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilderImpl.java
@@ -1,5 +1,6 @@
 package net.quantrax.messagebuilder;
 
+import net.quantrax.messagebuilder.util.Provider;
 import net.quantrax.messagebuilder.util.Services;
 
 import java.util.Optional;

--- a/src/main/java/net/quantrax/messagebuilder/util/Provider.java
+++ b/src/main/java/net/quantrax/messagebuilder/util/Provider.java
@@ -1,0 +1,13 @@
+package net.quantrax.messagebuilder.util;
+
+import net.quantrax.messagebuilder.MessageBuilder;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+public interface Provider {
+
+	@ApiStatus.Internal
+	@PlatformAPI
+	@NotNull MessageBuilder messageBuilder();
+
+}


### PR DESCRIPTION
The Provider class has been moved from MessageBuilder to the util package. This refactoring was done to maintain more coherent and organized code. The import statements in the MessageBuilder and MessageBuilderImpl classes were updated accordingly.