### PR TITLE
Add language setting tests and MockBukkit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,8 @@ repositories {
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.2-R0.1-SNAPSHOT")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    implementation("com.github.seeseemelk:MockBukkit-v1.20:3.58.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
+++ b/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
@@ -1,13 +1,36 @@
 package net.quantrax.messagebuilder;
 
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MessageBuilderTest {
 
 	private static MessageBuilder messageBuilder;
+	private ServerMock server;
+	private PlayerMock player;
+
+	@BeforeEach
+	void setUp() {
+		server = MockBukkit.mock();
+		player = server.addPlayer();
+
+		player.setLocale(Locale.ENGLISH);
+	}
+
+	@AfterEach
+	void tearDown() {
+		MockBukkit.unmock();
+	}
 
 	@BeforeAll
 	static void init() {
@@ -17,6 +40,22 @@ public class MessageBuilderTest {
 	@Test
 	void initDoesNotFail() {
 		assertNotNull(messageBuilder, "The MessageBuilder instance is null");
+	}
+
+	@Test
+	void languageIsGerman() {
+		Language expected = Language.GERMAN;
+		Language actual = messageBuilder.language(Language.GERMAN).language();
+
+		assertEquals(expected, actual, "The manually selected language does not match with the expected language. Expected: %s, actual: %s".formatted(expected, actual));
+	}
+
+	@Test
+	void localizedIsEnglish() {
+		Language expected = Language.ENGLISH;
+		Language actual = messageBuilder.localized(player).language();
+
+		assertEquals(expected, actual, "The auto-fetched language from the player does not match with the expected language. Expected: %s, actual: %s".formatted(expected, actual));
 	}
 
 }


### PR DESCRIPTION
Added two new tests in MessageBuilderTest to check the functionality of manual and auto-fetched language settings. Also, integrated the MockBukkit testing utility to simulate a server environment during the unit tests. Updated junit version in build related files accordingly.