### PR TITLE
Refactor configuration loading and database setup

### DIFF
--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
@@ -2,6 +2,7 @@ package net.quantrax.messagebuilder;
 
 import net.quantrax.messagebuilder.stage.LanguageStage;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public interface MessageBuilder {
@@ -10,7 +11,11 @@ public interface MessageBuilder {
 		return MessageBuilderImpl.Instances.INSTANCE;
 	}
 
+	@ApiStatus.Internal
 	void setup();
+
+	@ApiStatus.Internal
+	void destroy();
 
 	@NotNull LanguageStage language(@NotNull Language language);
 

--- a/src/main/java/net/quantrax/messagebuilder/backend/database/Credentials.java
+++ b/src/main/java/net/quantrax/messagebuilder/backend/database/Credentials.java
@@ -1,0 +1,4 @@
+package net.quantrax.messagebuilder.backend.database;
+
+public record Credentials(String host, String port, String database, String username, String password) {
+}

--- a/src/main/java/net/quantrax/messagebuilder/backend/database/Properties.java
+++ b/src/main/java/net/quantrax/messagebuilder/backend/database/Properties.java
@@ -1,4 +1,0 @@
-package net.quantrax.messagebuilder.backend.database;
-
-public record Properties(String host, String port, String database, String username, String password) {
-}

--- a/src/main/java/net/quantrax/messagebuilder/backend/database/StaticSaduLoader.java
+++ b/src/main/java/net/quantrax/messagebuilder/backend/database/StaticSaduLoader.java
@@ -6,12 +6,14 @@ import de.chojo.sadu.datasource.DataSourceCreator;
 
 public class StaticSaduLoader {
 
-	public static void start(Properties properties) {
+	public static HikariDataSource start(Credentials properties) {
 		final HikariDataSource source = createSource(properties);
 		StaticQueryAdapter.start(source);
+
+		return source;
 	}
 
-	private static HikariDataSource createSource(Properties properties) {
+	private static HikariDataSource createSource(Credentials properties) {
 		return DataSourceCreator.create(MariaDb.get())
 				.configure(config -> config.host(properties.host()).port(properties.port()).database(properties.database()).user(properties.username()).password(properties.password()))
 				.create()

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,0 +1,5 @@
+host=localhost
+port=3306
+database=language
+user=root
+password=

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -1,6 +1,0 @@
-[database-credentials]
-host = "localhost"
-port = "3306"
-database = "language"
-username = "root"
-password = ""


### PR DESCRIPTION
Switched from using a TOML file to a properties file for configuration loading. Updated the database setup process to use these new properties to set up a HikariDataSource, then used this data source to start a StaticSaduLoader. Also moved the initialization of the MessageBuilder from "config.toml" to "config.properties".