### PR TITLE
Refactor MessageBuilderTest and enhance localization functionality

### DIFF
--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilder.java
@@ -5,6 +5,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+import java.util.Map;
+
 public interface MessageBuilder {
 
 	static @NotNull MessageBuilder messageBuilder() {
@@ -16,6 +19,9 @@ public interface MessageBuilder {
 
 	@ApiStatus.Internal
 	void destroy();
+
+	@ApiStatus.Internal
+	@NotNull Map<Language, List<Message>> localizedMessages();
 
 	@NotNull LanguageStage language(@NotNull Language language);
 

--- a/src/main/java/net/quantrax/messagebuilder/MessageBuilderImpl.java
+++ b/src/main/java/net/quantrax/messagebuilder/MessageBuilderImpl.java
@@ -19,10 +19,7 @@ public class MessageBuilderImpl implements MessageBuilder {
 
 	private static final Logger LOGGER = Logger.getLogger(MessageBuilderImpl.class.getName());
 	private static final Optional<Provider> SERVICE = Services.service(Provider.class);
-
-	@ApiStatus.Internal
 	private HikariDataSource hikariDataSource;
-
 	private final Map<Language, List<Message>> localizedMessages = new HashMap<>();
 
 	@Override
@@ -65,6 +62,11 @@ public class MessageBuilderImpl implements MessageBuilder {
 		return new LanguageStage(suitableLanguage);
 	}
 
+	@Override
+	public @NotNull Map<Language, List<Message>> localizedMessages() {
+		return this.localizedMessages;
+	}
+
 	private void fetchMessages() {
 		for (Language language : Language.values()) {
 			Language.messages(language)
@@ -73,7 +75,6 @@ public class MessageBuilderImpl implements MessageBuilder {
 						LOGGER.severe(throwable.getLocalizedMessage());
 						return Collections.emptyList();
 					});
-
 		}
 	}
 

--- a/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
+++ b/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
@@ -5,31 +5,28 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.junit.jupiter.api.*;
 
+import java.util.List;
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MessageBuilderTest {
 
-	private static MessageBuilder messageBuilder;
-	private ServerMock server;
 	private PlayerMock player;
 
 	@BeforeAll
 	static void setup() {
-		messageBuilder = MessageBuilder.messageBuilder();
-		messageBuilder.setup();
+		MessageBuilder.messageBuilder().setup();
 	}
 
 	@AfterAll
 	static void destroy() {
-		messageBuilder.destroy();
+		MessageBuilder.messageBuilder().destroy();
 	}
 
 	@BeforeEach
 	void setUp() {
-		server = MockBukkit.mock();
+		ServerMock server = MockBukkit.mock();
 		player = server.addPlayer();
 
 		player.setLocale(Locale.ENGLISH);
@@ -42,13 +39,13 @@ public class MessageBuilderTest {
 
 	@Test
 	void initDoesNotFail() {
-		assertNotNull(messageBuilder, "The MessageBuilder instance is null");
+		assertNotNull(MessageBuilder.messageBuilder(), "The MessageBuilder instance is null");
 	}
 
 	@Test
 	void languageIsGerman() {
 		Language expected = Language.GERMAN;
-		Language actual = messageBuilder.language(Language.GERMAN).language();
+		Language actual = MessageBuilder.messageBuilder().language(Language.GERMAN).language();
 
 		assertEquals(expected, actual, "The manually selected language does not match with the expected language. Expected: %s, actual: %s".formatted(expected, actual));
 	}
@@ -56,9 +53,23 @@ public class MessageBuilderTest {
 	@Test
 	void localizedIsEnglish() {
 		Language expected = Language.ENGLISH;
-		Language actual = messageBuilder.localized(player).language();
+		Language actual = MessageBuilder.messageBuilder().localized(player).language();
 
 		assertEquals(expected, actual, "The auto-fetched language from the player does not match with the expected language. Expected: %s, actual: %s".formatted(expected, actual));
+	}
+
+	@Test
+	void noGermanMessagesFetched() {
+		final List<Message> germanMessages = MessageBuilder.messageBuilder().localizedMessages().get(Language.GERMAN);
+
+		assertTrue(germanMessages.isEmpty(), "German messages were found.");
+	}
+
+	@Test
+	void englishMessagesFound() {
+		final List<Message> englishMessages = MessageBuilder.messageBuilder().localizedMessages().get(Language.ENGLISH);
+
+		assertFalse(englishMessages.isEmpty(), "There was no english message found.");
 	}
 
 }


### PR DESCRIPTION
Refactored MessageBuilderTest, removing redundant server object and using explicit method calls on MessageBuilder. Improved localization by storing localized messages in a Map within the MessageBuilderImpl class. Added two new tests for validating the absence of German messages and presence of English messages. The aim is to enhance performance and provide simpler management of localized messages.