### PR TITLE
Add new 'confirmResolving' test method in MessageBuilderTest

### DIFF
--- a/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
+++ b/src/test/java/net/quantrax/messagebuilder/MessageBuilderTest.java
@@ -3,6 +3,8 @@ package net.quantrax.messagebuilder;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
@@ -70,6 +72,14 @@ public class MessageBuilderTest {
 		final List<Message> englishMessages = MessageBuilder.messageBuilder().localizedMessages().get(Language.ENGLISH);
 
 		assertFalse(englishMessages.isEmpty(), "There was no english message found.");
+	}
+
+	@Test
+	void confirmResolving() {
+		final Component expected = MiniMessage.miniMessage().deserialize("<red>Test<red>");
+		final Component actual = MessageBuilder.messageBuilder().localized(player).message("test.test");
+
+		assertEquals(expected, actual, "The resolved component does not match with the expectation.");
 	}
 
 }


### PR DESCRIPTION
A new test method, 'confirmResolving', is added in the MessageBuilderTest.java file to confirm the resolution of messages. Two new imports, Component and MiniMessage from net.kyori.adventure.text, are added to support this. The test ensures the resolved component matches the expected output.